### PR TITLE
remove dplyr and tibble from dependencies

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,6 +17,4 @@ Depends: R (>= 2.10)
 Suggests: 
     testthat
 Imports:
-    magrittr,
-    dplyr,
-    tibble
+    magrittr

--- a/R/utils.R
+++ b/R/utils.R
@@ -76,8 +76,13 @@ processTable <- function(rules_for_table, lovs, count) {
 
   rls <-
     rules_for_table %>%
-    dplyr::mutate(Evaluation.Sequence = dplyr::coalesce(as.integer(Evaluation.Sequence), 0L)) %>%
-    dplyr::arrange(Evaluation.Sequence) %>%
+    magrittr::inset(
+      "Evaluation.Sequence",
+      value = ifelse(is.na(.$Evaluation.Sequence), 0, .$Evaluation.Sequence)
+    ) %>%
+    extract(
+      order(.$Evaluation.Sequence),
+    ) %>%
     nest_df(df = ., column = "Attribute")
 
   result <-

--- a/tests/testthat/test-generator.R
+++ b/tests/testthat/test-generator.R
@@ -2,9 +2,23 @@ library(synthezator)
 
 test_that("Generate vector of required size", {
   c <- 100
-  g <- generateAttr(
+  d <- generateAttr(
+    count = c, attr_type = "Date", fix_offset_value = "19991231"
+  )
+  n <- generateAttr(
+    count = c, attr_type = "Number", fix_offset_value = "1.54"
+  )
+  v <- generateAttr(
     count = c, attr_type = "Varchar", fix_offset_value = "Hello world!"
   )
-  expect_equal(length(g), c)
+  expect_equal(length(d), c)
+  expect_equal(length(n), c)
+  expect_equal(length(v), c)
+})
+
+test_that("Cast values", {
+  expect_equal(castValue("19991231", "Date"), as.Date("1999-12-31"))
+  expect_equal(castValue("1.43", "Number"), 1.43)
+  expect_equal(castValue("abcd", "Varchar"), "abcd")
 })
 


### PR DESCRIPTION
this PR resolves #1 

tidy verse takes ages to install and check in travis. it is also very heavy when being installed on workstation. this change removes dependency on dplyr: `mutate` function and `arrange` function. These two functions were replaced with core R functionality but with help of `magrittr` package to make it less imperative and more compositional:
* Function `dplyr::mutate` was replaces with `inset` (`df[x] <- ...` is the same as `df %>% inset("x", value = ...)`) 
* Function `dplyr::arrange` was replaced with `extract` (`df[order(x),]` is the same as `df %>% extract(order(.$x),)`)